### PR TITLE
feat: detect hardcoded Anthropic (Claude) API keys

### DIFF
--- a/src/pyspector/rules/built-in-rules.toml
+++ b/src/pyspector/rules/built-in-rules.toml
@@ -2143,3 +2143,11 @@ confidence = "Low"
 remediation = "Validate format strings and use safe formatting methods."
 ast_match = "Call(func.id=format)"
 file_pattern = "*.py"
+
+[[rule]]
+id = "AI002"
+description = "Hardcoded Anthropic (Claude) API key detected."
+severity = "High"
+remediation = "Remove hardcoded API keys and load them from environment variables or a secure secrets manager."
+pattern = "(?i)sk-ant-api[0-9]*-[A-Za-z0-9_-]{20,}"
+file_pattern = ".*\\.py"

--- a/tests/examples/hardcoded_anthropic_key.py
+++ b/tests/examples/hardcoded_anthropic_key.py
@@ -1,0 +1,4 @@
+ANTHROPIC_API_KEY = "sk-ant-api03-FAKEKEYFORTESTING-ABCDEF1234567890"
+
+def example():
+    pass


### PR DESCRIPTION
Adds a new security rule to detect hardcoded Anthropic (Claude) API keys.

- Regex-based detection for `sk-ant-*` keys
- High severity with remediation guidance
- Includes an example file demonstrating detection

This expands AI/LLM credential leakage coverage.
