### PR TITLE
Group scan output by severity level

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core application dependencies
 click>=8.0
 toml>=0.10
+requests>=2.25
 sarif-om>=1.0
 jinja2>=3.0 # For HTML reporting
 # For the interactive TUI

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "click>=8.0",
         "toml>=0.10",
+        "requests>=2.25",
         "sarif-om>=1.0",
         "jinja2>=3.0",
         "textual>=0.60",

--- a/src/pyspector/reporting.py
+++ b/src/pyspector/reporting.py
@@ -23,17 +23,40 @@ class Reporter:
             return "\nNo issues found."
 
         output = []
-        # Sort by file path and then line number
-        sorted_issues = sorted(self.issues, key=lambda i: (i.file_path, i.line_number))
-        
-        for issue in sorted_issues:
-            output.append(
-                f"\n[+] Rule ID: {issue.rule_id}\n"
-                f"    Description: {issue.description}\n"
-                f"    Severity: {str(issue.severity).split('.')[-1].upper()}\n"
-                f"    File: {issue.file_path}:{issue.line_number}\n"
-                f"    Code: `{issue.code.strip()}`"
-            )
+
+        # Define severity order (highest to lowest priority)
+        severity_order = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']
+
+        # Group issues by severity
+        issues_by_severity = {}
+        for issue in self.issues:
+            severity = str(issue.severity).split('.')[-1].upper()
+            if severity not in issues_by_severity:
+                issues_by_severity[severity] = []
+            issues_by_severity[severity].append(issue)
+
+        # Output grouped by severity (in priority order)
+        for severity in severity_order:
+            if severity not in issues_by_severity:
+                continue
+
+            issues = issues_by_severity[severity]
+            # Sort issues within each severity group by file path and line number
+            sorted_issues = sorted(issues, key=lambda i: (i.file_path, i.line_number))
+
+            # Add severity header
+            output.append(f"\n{'='*60}")
+            output.append(f"  {severity} ({len(sorted_issues)} issue{'s' if len(sorted_issues) != 1 else ''})")
+            output.append(f"{'='*60}")
+
+            for issue in sorted_issues:
+                output.append(
+                    f"\n[+] Rule ID: {issue.rule_id}\n"
+                    f"    Description: {issue.description}\n"
+                    f"    File: {issue.file_path}:{issue.line_number}\n"
+                    f"    Code: `{issue.code.strip()}`"
+                )
+
         return "\n".join(output)
 
     def to_json(self) -> str:


### PR DESCRIPTION
## Summary
- Console output now groups issues by severity (CRITICAL, HIGH, MEDIUM, LOW) with headers showing issue counts
- Issues within each severity group are sorted by file path and line number
- Added missing `requests` dependency to requirements.txt and setup.py

## Before
```
[+] Rule ID: PY001
    Severity: HIGH
    ...
[+] Rule ID: PY201
    Severity: MEDIUM
    ...
[+] Rule ID: PY305
    Severity: CRITICAL
    ...
```

## After
```
============================================================
  CRITICAL (1 issue)
============================================================

[+] Rule ID: PY305
    ...

============================================================
  HIGH (4 issues)
============================================================

[+] Rule ID: PY001
    ...
```

## Test plan
- [x] Tested with sample vulnerable code containing multiple severity levels
- [x] Verified output groups correctly by CRITICAL > HIGH > MEDIUM > LOW
- [x] Verified issue counts in headers are accurate

Fixes #9