### PR TITLE
Fix panic on non-UTF-8 file paths in analysis walker

### DIFF
--- a/src/pyspector/_rust_core/src/analysis/mod.rs
+++ b/src/pyspector/_rust_core/src/analysis/mod.rs
@@ -38,7 +38,9 @@ pub fn run_analysis(context: AnalysisContext) -> Vec<Issue> {
         let path = entry.path();
         // Collect all files (not just .py) for regex scanning
         if path.is_file() && !is_excluded(path, &enhanced_exclusions) {
-            files_to_scan.push(path.to_str().unwrap().to_string());
+            if let Some(s) = path.to_str() {
+                files_to_scan.push(s.to_string());
+            }
         }
     }
     


### PR DESCRIPTION
There is a stack trace being triggered when trying to parse a couple of filenames that are not using UTF-8 on their filenames that are part of the repo `V3lectronics/SPIRIT`:
- EDA-kicad/component-libs/SPIRIT-3D-models/UBAF30-D2011�+�3D�+�.STEP
- EDA-kicad/component-libs/SPIRIT-3D-models/UBAF30-D2011´+ê3D´+ë.STEP

Step to reproduce:
`satori run satori://code/python/pyspector.yml --repo V3lectronics/SPIRIT --output`

<img width="962" height="834" alt="image" src="https://github.com/user-attachments/assets/f9796879-b635-422a-8457-4e834f2f3a0f" />

The proposed fix seems to be able to work with this repo:
<img width="726" height="859" alt="image" src="https://github.com/user-attachments/assets/af625d30-df9c-4f97-bd4a-61f98d379f0e" />
