### PR TITLE
Replace oversized int literals with 0 to avoid json.dumps 4300-digit conversion limit

### DIFF
--- a/src/pyspector/cli.py
+++ b/src/pyspector/cli.py
@@ -74,6 +74,8 @@ class AstEncoder(json.JSONEncoder):
                     # Handle non-JSON serializable types
                     if isinstance(value, bytes):
                         simple_fields[field] = value.decode('utf-8', errors='replace')
+                    elif isinstance(value, int) and value.bit_length() > 14000:
+                        simple_fields[field] = 0
                     elif isinstance(value, (int, float, str, bool)) or value is None:
                         simple_fields[field] = value
                     else:


### PR DESCRIPTION
When PySpector processes the following:

https://github.com/SheafificationOfG/BoolosBrewery/blob/18670136ed43ca9ed30bf6b701b47fc48307bfa7/submissions/public/hard/20241015_010940_viliml_simpler_sat.py#L7

A stacktrace is shown:
`satori run satori://code/python/pyspector.yml --repo SheafificationOfG/BoolosBrewery --output`

<img width="894" height="687" alt="image" src="https://github.com/user-attachments/assets/8ccee294-ccb4-4a8c-a8fd-0781e8a3a42f" />

When `ast.parse()` parses the file, it creates AST Constant nodes with those huge integers. Then `json.dumps()` tries to convert them to strings and hits Python 3.12's int-to-string security limit (CVE-2020-10735), which caps conversions at 4,300 digits by default.                                                                              
                                                                                                                                                                                 
This is a bug in PySpector's AstEncoder — it should handle huge integers gracefully instead of letting json.dumps crash. The fix would be in cli.py's `AstEncoder.default()` method, converting very large ints to a 0 before serialization.

With this fix, it is possible to parse that repo:
<img width="1244" height="545" alt="image" src="https://github.com/user-attachments/assets/46a5d1c4-b3c0-461d-9281-a9ec244816a3" />
