### PR TITLE
feat: detect trust_remote_code model loading

### DIFF
--- a/src/pyspector/rules/built-in-rules-ai.toml
+++ b/src/pyspector/rules/built-in-rules-ai.toml
@@ -256,6 +256,15 @@ file_pattern = "*.py"
 cwe = "CWE-502"
 
 [[rule]]
+id = "AI206"
+description = "Hugging Face model loading enables remote repository code execution."
+severity = "High"
+remediation = "Avoid `trust_remote_code=True` for untrusted model repositories. Prefer models that do not require custom code, or pin and audit the exact repository revision before enabling remote code."
+ast_match = "Call(func.attr=from_pretrained, keywords.*.arg=trust_remote_code, keywords.*.value.value=True)"
+file_pattern = "*.py"
+cwe = "CWE-94"
+
+[[rule]]
 id = "AI205"
 description = "Loading a model using `tf.keras.models.load_model` with `compile=False` can still pose a risk if the model architecture itself is malicious."
 severity = "Medium"

--- a/tests/unit/test_ai_rules.py
+++ b/tests/unit/test_ai_rules.py
@@ -1,0 +1,134 @@
+import ast
+import json
+import os
+import sys
+import tempfile
+import textwrap
+import warnings
+from pathlib import Path
+
+import pytest
+import toml
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+RULES_PATH = Path(__file__).parent.parent.parent / "src/pyspector/rules/built-in-rules-ai.toml"
+AI206_MATCHER = (
+    "Call(func.attr=from_pretrained, keywords.*.arg=trust_remote_code, "
+    "keywords.*.value.value=True)"
+)
+
+
+def _wrap(code: str) -> str:
+    indented = "\n".join("    " + line for line in textwrap.dedent(code).splitlines())
+    return f"def _load_model():\n{indented}\n"
+
+
+def _ai206_rule() -> dict:
+    rules = toml.loads(RULES_PATH.read_text(encoding="utf-8"))
+    return next(rule for rule in rules["rule"] if rule["id"] == "AI206")
+
+
+def _ast_node(node: ast.AST) -> dict:
+    children = {}
+    fields = {}
+    for field, value in ast.iter_fields(node):
+        if isinstance(value, list):
+            if value and all(isinstance(item, ast.AST) for item in value):
+                children[field] = [_ast_node(item) for item in value]
+            else:
+                fields[field] = str(value) if value else []
+        elif isinstance(value, ast.AST):
+            children[field] = [_ast_node(value)]
+        else:
+            fields[field] = value if isinstance(value, (int, float, str, bool)) or value is None else str(value)
+    return {"node_type": node.__class__.__name__, "children": children, "fields": fields}
+
+
+def _has_property(node: dict, path: list[str], expected: str) -> bool:
+    if not path:
+        return False
+    current, remaining = path[0], path[1:]
+    if not remaining and current in node["fields"]:
+        value = node["fields"][current]
+        if isinstance(value, bool):
+            return str(value).lower() == expected.lower()
+        return str(value) == expected
+    if current in node["children"]:
+        if remaining and remaining[0] == "*":
+            return any(_has_property(child, remaining[1:], expected) for child in node["children"][current])
+        if remaining and node["children"][current]:
+            return _has_property(node["children"][current][0], remaining, expected)
+    return False
+
+
+def _matches_ai206(code: str) -> bool:
+    node = _ast_node(ast.parse(code).body[0].value)
+    node_type, props = AI206_MATCHER.split("(", 1)
+    props = props.rsplit(")", 1)[0]
+    return node["node_type"] == node_type and all(
+        _has_property(node, path.strip().split("."), expected)
+        for path, expected in (part.strip().split("=", 1) for part in props.split(","))
+    )
+
+
+def run_pyspector_ai(code: str, filename: str = "model_loader.py") -> list[dict]:
+    try:
+        from pyspector._rust_core import run_scan
+        from pyspector.cli import AstEncoder
+        from pyspector.config import get_default_rules
+    except (ImportError, SystemExit) as exc:
+        pytest.skip(f"PySpector Rust core is not available: {exc}")
+
+    wrapped = _wrap(code)
+    rules_toml = get_default_rules(ai_scan=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, filename)
+        Path(path).write_text(wrapped)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            try:
+                ast_json = json.dumps(ast.parse(wrapped), cls=AstEncoder)
+            except Exception:
+                ast_json = "{}"
+        files = [{"file_path": filename, "content": wrapped, "ast_json": ast_json}]
+        results = run_scan(tmpdir, rules_toml, {"exclude": []}, files)
+
+    return [{"rule_id": result.rule_id, "line_number": result.line_number} for result in results]
+
+
+def fires(code: str, rule_id: str) -> bool:
+    return any(result["rule_id"] == rule_id for result in run_pyspector_ai(code))
+
+
+class TestAI206:
+    def test_rule_metadata(self):
+        rule = _ai206_rule()
+        assert rule["severity"] == "High"
+        assert rule["cwe"] == "CWE-94"
+        assert rule["ast_match"] == AI206_MATCHER
+
+    def test_matcher_targets_true_keyword_only(self):
+        true_code = 'AutoModelForCausalLM.from_pretrained("example/model", trust_remote_code=True)'
+        false_code = 'AutoModelForCausalLM.from_pretrained("example/model", trust_remote_code=False)'
+        assert _matches_ai206(true_code)
+        assert not _matches_ai206(false_code)
+
+    def test_trust_remote_code_true_fires(self):
+        code = """
+            model = AutoModelForCausalLM.from_pretrained(
+                "example/model",
+                trust_remote_code=True,
+            )
+        """
+        assert fires(code, "AI206")
+
+    def test_trust_remote_code_false_safe(self):
+        code = """
+            model = AutoModelForCausalLM.from_pretrained(
+                "example/model",
+                trust_remote_code=False,
+            )
+        """
+        assert not fires(code, "AI206")


### PR DESCRIPTION
## Summary
- add AI206 to flag Hugging Face `from_pretrained(..., trust_remote_code=True)` model loading
- add targeted tests for the rule metadata, matcher behavior, and scanner integration when the Rust core is available

Closes #18

## Validation
- `/tmp/pyspector-pdlc043-venv/bin/python -m pytest tests/unit/test_ai_rules.py -q` -> 2 passed, 2 skipped locally because the PySpector Rust core is not available in this runner
- `/tmp/pyspector-pdlc043-venv/bin/python -m py_compile tests/unit/test_ai_rules.py`
- TOML parse check for `src/pyspector/rules/built-in-rules-ai.toml`
- direct AST matcher shape check for `trust_remote_code=True` vs `False`
- `git diff --check`