### PR TITLE
docs: document the new watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,46 @@ pyspector scan --url https://github.com/username/repo.git
 pyspector scan --wizard
 ```
 
+
+
+### Watching for Changes
+
+The `watch` command continuously monitors a directory or file and re-runs the scan whenever a `.py` file is created, modified, or deleted — ideal for real-time feedback during development.
+
+```bash
+pyspector watch [PATH] [OPTIONS]
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `path` | Directory or file to watch (required) |
+| `-s, --severity LEVEL` | Minimum severity to report: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` (default: `LOW`) |
+| `--ai` | Enable AI/LLM vulnerability scanning rules |
+| `-c, --config FILE` | Path to a `pyspector.toml` config file |
+| `--debounce SECONDS` | Wait time after last change before re-scanning (default: 1.0s) |
+| `--debug` | Show verbose progress output |
+
+#### Examples
+
+- **Watch a project directory for changes:**
+```bash
+pyspector watch ./my-project
+```
+
+- **Watch with minimum HIGH severity:**
+```bash
+pyspector watch ./my-project --severity HIGH
+```
+
+- **Watch with debounce (wait 2s after last change):**
+```bash
+pyspector watch ./my-project --debounce 2.0
+```
+
+On each re-scan, only **new** and **resolved** findings are printed, so you can track your security posture as you code. Exit with `Ctrl+C`.
+
 ### Scan for AI and LLM Vulnerabilities
 
 <img width="970" height="1096" alt="image" src="https://github.com/user-attachments/assets/14bac1c0-eae2-4dab-ab40-8047b46bbac8" />

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ pyspector scan /path/to/your/project -o report.html -f html
 pyspector scan --url https://github.com/username/repo.git
 ```
 
-### Wizard Mode for Beginners (NEW FEATURE🚀)
+### Wizard Mode for Beginners
 
 <img width="864" height="1098" alt="image" src="https://github.com/user-attachments/assets/5094fef9-73d1-4d34-b530-9498d923a514" />
 
@@ -201,11 +201,9 @@ pyspector scan --url https://github.com/username/repo.git
 pyspector scan --wizard
 ```
 
-
-
 ### Watching for Changes
 
-The `watch` command continuously monitors a directory or file and re-runs the scan whenever a `.py` file is created, modified, or deleted — ideal for real-time feedback during development.
+The `watch` command continuously monitors a directory or file and re-runs the scan whenever a `.py` file is created, modified, or deleted, ideal for real-time feedback during development.
 
 ```bash
 pyspector watch [PATH] [OPTIONS]


### PR DESCRIPTION
## Summary

Documents the `watch` command added in v0.2.0 (referenced in issue #78).

The watch command continuously monitors a directory for `.py` file changes and re-runs the scan automatically. This is useful for real-time security feedback during development.

### What was added

A new "Watching for Changes" subsection under Usage, documenting:
- Command syntax and options
- `--severity`, `--ai`, `--config`, `--debounce`, `--debug` flags
- Usage examples for common scenarios

Closes #78
