### PR TITLE
Docs/update pre commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ pyspector watch [PATH] [OPTIONS]
 | `-c, --config FILE` | Path to a `pyspector.toml` config file |
 | `--debounce SECONDS` | Wait time after last change before re-scanning (default: 1.0s) |
 | `--debug` | Show verbose progress output |
+| `--msg BOOL` | Enable or disable the rotating contact message shown below the banner (`--msg=True` / `--msg=False`). The setting persists across future runs until changed again, so it only needs to be set once |
 
 #### Examples
 
@@ -341,7 +342,6 @@ pyspector scan ./project -f sarif -o report.sarif
 The generated `report.sarif` file can then be uploaded to supported security platforms for analysis and visualization.
 
 ### Git Pre-Commit Hook
-
 
 To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the [pre-commit](https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
 
@@ -474,8 +474,19 @@ pyspector scan ./my-python-project --debug
 </details>
 
 <details>
+<summary>How do I disable the contact message shown below the banner?</summary>
+
+PySpector occasionally shows a rotating message below the banner with contact info. Use `--msg=False` to turn it off, or `--msg=True` to turn it back on. The setting is persisted to a per-user preferences file, so it only needs to be set once and applies to all future runs of `scan`, `watch`, and the wizard:
+
+```bash
+pyspector scan ./my-python-project --msg=False
+```
+
+</details>
+
+<details>
 <summary>How can I integrate PySpector into CI?</summary>
 
-For CI pipelines, generate SARIF with -f sarif and upload it to a compatible security platform such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.
+For CI pipelines, generate SARIF with `-f sarif` and upload it to a compatible security platform, such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -342,15 +342,19 @@ The generated `report.sarif` file can then be uploaded to supported security pla
 
 ### Git Pre-Commit Hook
 
-To ensure that no new high-severity issues are introduced into the codebase, you can set up a Git pre-commit hook. This hook will automatically scan staged Python files before each commit and block the commit if any HIGH or CRITICAL issues are found.
 
-**To set up the hook, run the following script from the root of your Git repository:**
+To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the pre-commit (https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
 
-```bash
-./scripts/setup_hooks.sh
-```
+Add the following to your .pre-commit-config.yaml:
+repos:
+  - repo: https://github.com/ParzivalHack/PySpector
+    rev: v0.2.1-beta
+    hooks:
+      - id: pyspector
+Then install the hook:
+pre-commit install
 
-This script creates an executable .git/hooks/pre-commit file that performs the check. You can bypass the hook for a specific commit by using the --no-verify flag with your git commit command.
+You can bypass the hook for a single commit using git commit --no-verify.
 
 ## Scheduled Scans with Cron
 
@@ -465,6 +469,6 @@ pyspector scan ./my-python-project --debug
 <details>
 <summary>How can I integrate PySpector into CI?</summary>
 
-For CI pipelines, generate SARIF with `-f sarif` and upload it to a compatible security platform such as GitHub Code Scanning. For local guardrails, use `./scripts/setup_hooks.sh` to install the provided pre-commit hook.
+For CI pipelines, generate SARIF with -f sarif and upload it to a compatible security platform such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -343,18 +343,25 @@ The generated `report.sarif` file can then be uploaded to supported security pla
 ### Git Pre-Commit Hook
 
 
-To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the pre-commit (https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
+To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the [pre-commit](https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
 
-Add the following to your .pre-commit-config.yaml:
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
 repos:
   - repo: https://github.com/ParzivalHack/PySpector
     rev: v0.2.1-beta
     hooks:
       - id: pyspector
-Then install the hook:
-pre-commit install
+```
 
-You can bypass the hook for a single commit using git commit --no-verify.
+Then install the hook:
+
+```bash
+pre-commit install
+```
+
+You can bypass the hook for a single commit using `git commit --no-verify`.
 
 ## Scheduled Scans with Cron
 


### PR DESCRIPTION
## Changes

### README.md
- I have replaced the old **Git Pre-Commit Hook** section that referenced the deleted `scripts/setup_hooks.sh`.
- Updated the FAQ to recommend using the new `.pre-commit-hooks.yaml`.

## Follow-up (not included in this PR)

The website (`index.html`) should be updated to match:

- Replace the **Git pre-commit hook** subsection.
- Remove the old **pre-commit framework** subsection.
- Remove the paragraph referencing `setup_hooks.sh`.
- Update the FAQ.