### PR TITLE
 Updated pre-commit hook docs to remove setup_hooks.sh references

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ pyspector watch [PATH] [OPTIONS]
 | `-c, --config FILE` | Path to a `pyspector.toml` config file |
 | `--debounce SECONDS` | Wait time after last change before re-scanning (default: 1.0s) |
 | `--debug` | Show verbose progress output |
+| `--msg BOOL` | Enable or disable the rotating contact message shown below the banner (`--msg=True` / `--msg=False`). The setting persists across future runs until changed again, so it only needs to be set once |
 
 #### Examples
 
@@ -341,7 +342,6 @@ pyspector scan ./project -f sarif -o report.sarif
 The generated `report.sarif` file can then be uploaded to supported security platforms for analysis and visualization.
 
 ### Git Pre-Commit Hook
-
 
 To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the [pre-commit](https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
 
@@ -474,8 +474,19 @@ pyspector scan ./my-python-project --debug
 </details>
 
 <details>
+<summary>How do I disable the contact message shown below the banner?</summary>
+
+PySpector occasionally shows a rotating message below the banner with contact info. Use `--msg=False` to turn it off, or `--msg=True` to turn it back on. The setting is persisted to a per-user preferences file, so it only needs to be set once and applies to all future runs of `scan`, `watch`, and the wizard:
+
+```bash
+pyspector scan ./my-python-project --msg=False
+```
+
+</details>
+
+<details>
 <summary>How can I integrate PySpector into CI?</summary>
 
-For CI pipelines, generate SARIF with -f sarif and upload it to a compatible security platform such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.
+For CI pipelines, generate SARIF with `-f sarif` and upload it to a compatible security platform, such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -342,15 +342,19 @@ The generated `report.sarif` file can then be uploaded to supported security pla
 
 ### Git Pre-Commit Hook
 
-To ensure that no new high-severity issues are introduced into the codebase, you can set up a Git pre-commit hook. This hook will automatically scan staged Python files before each commit and block the commit if any HIGH or CRITICAL issues are found.
 
-**To set up the hook, run the following script from the root of your Git repository:**
+To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the pre-commit (https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
 
-```bash
-./scripts/setup_hooks.sh
-```
+Add the following to your .pre-commit-config.yaml:
+repos:
+  - repo: https://github.com/ParzivalHack/PySpector
+    rev: v0.2.1-beta
+    hooks:
+      - id: pyspector
+Then install the hook:
+pre-commit install
 
-This script creates an executable .git/hooks/pre-commit file that performs the check. You can bypass the hook for a specific commit by using the --no-verify flag with your git commit command.
+You can bypass the hook for a single commit using git commit --no-verify.
 
 ## Scheduled Scans with Cron
 
@@ -465,6 +469,6 @@ pyspector scan ./my-python-project --debug
 <details>
 <summary>How can I integrate PySpector into CI?</summary>
 
-For CI pipelines, generate SARIF with `-f sarif` and upload it to a compatible security platform such as GitHub Code Scanning. For local guardrails, use `./scripts/setup_hooks.sh` to install the provided pre-commit hook.
+For CI pipelines, generate SARIF with -f sarif and upload it to a compatible security platform such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -343,18 +343,25 @@ The generated `report.sarif` file can then be uploaded to supported security pla
 ### Git Pre-Commit Hook
 
 
-To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the pre-commit (https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
+To ensure that no new high-severity issues enter your codebase, you can set up a Git pre-commit hook using the [pre-commit](https://pre-commit.com) framework. The hook will scan your staged Python files before each commit and block it if any HIGH or CRITICAL issues are found.
 
-Add the following to your .pre-commit-config.yaml:
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
 repos:
   - repo: https://github.com/ParzivalHack/PySpector
     rev: v0.2.1-beta
     hooks:
       - id: pyspector
-Then install the hook:
-pre-commit install
+```
 
-You can bypass the hook for a single commit using git commit --no-verify.
+Then install the hook:
+
+```bash
+pre-commit install
+```
+
+You can bypass the hook for a single commit using `git commit --no-verify`.
 
 ## Scheduled Scans with Cron
 

--- a/index.html
+++ b/index.html
@@ -1481,39 +1481,20 @@ jobs:
           </div>
 
           <h4>Git pre-commit hook</h4>
-          <p>Block commits that introduce new HIGH or CRITICAL issues. The setup script creates an executable <code>.git/hooks/pre-commit</code> that scans staged Python files:</p>
-          <div class="codeblock">
-            <div class="codeblock-head"><span class="codeblock-lang">bash</span><button class="copy-btn" data-copy="./scripts/setup_hooks.sh">Copy</button></div>
-            <pre><code><span class="c"># From the root of your Git repository:</span>
-<span class="p">$</span> ./scripts/setup_hooks.sh
-
-<span class="c"># Bypass for a specific commit if you must:</span>
-<span class="p">$</span> git <span class="f">commit</span> <span class="o">--no-verify</span></code></pre>
-          </div>
-
-          <h4>pre-commit framework</h4>
-          <p>If your team uses the <a href="https://pre-commit.com/" target="_blank" rel="noopener">pre-commit</a> framework, add PySpector as a local hook so it runs on staged Python files alongside your other checks:</p>
+          <p>Block commits that introduce new HIGH or CRITICAL issues. This hook uses the <a href="https://pre-commit.com/" target="_blank" rel="noopener">pre-commit</a> framework to scan staged Python files before each commit:</p>
           <div class="codeblock">
             <div class="codeblock-head"><span class="codeblock-lang">yaml · .pre-commit-config.yaml</span><button class="copy-btn" data-copy="repos:
-  - repo: local
+  - repo: https://github.com/ParzivalHack/PySpector
+    rev: v0.2.1-beta
     hooks:
-      - id: pyspector
-        name: PySpector SAST
-        entry: pyspector
-        args: [&quot;scan&quot;, &quot;.&quot;]
-        language: system
-        types: [python]">Copy</button></div>
+      - id: pyspector">Copy</button></div>
             <pre><code><span class="o">repos</span>:
-  - <span class="o">repo</span>: local
+  - <span class="o">repo</span>: https://github.com/ParzivalHack/PySpector
+    <span class="o">rev</span>: v0.2.1-beta
     <span class="o">hooks</span>:
-      - <span class="o">id</span>: pyspector
-        <span class="o">name</span>: PySpector SAST
-        <span class="o">entry</span>: pyspector
-        <span class="o">args</span>: [<span class="s">"scan"</span>, <span class="s">"."</span>]
-        <span class="o">language</span>: system
-        <span class="o">types</span>: [python]</code></pre>
+      - <span class="o">id</span>: pyspector</code></pre>
           </div>
-          <p>The bundled <code>./scripts/setup_hooks.sh</code> takes the stricter route: it installs a raw Git hook that scans only the staged files with <code>--severity HIGH</code> and blocks the commit on any HIGH or CRITICAL finding (bypass with <code>git commit --no-verify</code>).</p>
+          <p>Then run <code>pre-commit install</code> to activate the hook. Bypass with <code>git commit --no-verify</code>.</p>
 
           <h4>Scheduled scans with cron</h4>
           <p>For continuous monitoring outside CI, an interactive script generates the right crontab entry for your project:</p>
@@ -1613,7 +1594,7 @@ mypy src/">Copy</button></div>
           </details>
           <details class="faq-item">
             <summary>How do I integrate PySpector into CI?</summary>
-            <div class="faq-body">Generate SARIF with <code>-f sarif</code> and upload it to a compatible platform such as GitHub Code Scanning. For local guardrails, run <code>./scripts/setup_hooks.sh</code> to install the pre-commit hook.</div>
+            <div class="faq-body">Generate SARIF with <code>-f sarif</code> and upload it to a compatible platform such as GitHub Code Scanning. For local guardrails, use the Git Pre-Commit Hook described above.</div>
           </details>
           <details class="faq-item">
             <summary>Does my code ever leave my machine?</summary>


### PR DESCRIPTION
The `scripts/setup_hooks.sh` file was deleted and replaced with a
`.pre-commit-hooks.yaml` that integrates with the pre-commit framework.
The website (index.html) still referenced the old deleted script.

### Changes in index.html

1. **Git pre-commit hook section** — replaced the old `./scripts/setup_hooks.sh`
   instructions with the new pre-commit framework approach (remote repo config
   `repo: https://github.com/ParzivalHack/PySpector`)
2. **Removed** the redundant "pre-commit framework" subsection (old `repo: local`
   approach) and the paragraph referencing the deleted `setup_hooks.sh`
3. **FAQ CI question** — updated to point to the new pre-commit hook instead
   of the deleted script