### PR TITLE
Make the triage baseline use the same fingerprint the scanner compares

### DIFF
--- a/src/pyspector/triage.py
+++ b/src/pyspector/triage.py
@@ -13,7 +13,7 @@ def create_fingerprint(issue: Dict[str, Any]) -> str:
     # Use rule ID, file path relative to a potential project root, and the line content
     # This makes the fingerprint stable across different checkout directories
     unique_string = f"{issue.get('rule_id', '')}|{issue.get('file_path', '')}|{issue.get('line_number', '')}|{issue.get('code', '').strip()}"
-    return hashlib.sha256(unique_string.encode('utf-8')).hexdigest()
+    return hashlib.sha1(unique_string.encode('utf-8')).hexdigest()
 
 class PySpectorTriage(App):
     """An interactive TUI for triaging PySpector findings."""


### PR DESCRIPTION
Second of the two you invited on GHSA-7875-p889-5wvx, and independent of #94.

`create_fingerprint()` in `triage.py:16` hashes with SHA-256, while the scanner computes `get_fingerprint()` with SHA-1 in `_rust_core/src/issues.rs:69`, over the identical `rule_id|file_path|line_number|code` string. The TUI writes its SHA-256 digests into `.pyspector_baseline.json`, and `cli.py:903` then compares them against SHA-1 values, so nothing ever matches and a baseline saved from the triage view suppresses nothing.

I hit this by accident: a hand-built SHA-1 baseline dropped a finding while a SHA-256 one over the same string did not, which is what pointed at the mismatch.

Switching `triage.py` to SHA-1 makes the two agree. Going the other way and moving the Rust side to SHA-256 would work equally well, but it invalidates any baseline anyone has, whereas nothing can regress here since no TUI-written baseline was ever matched in the first place. Happy to do it that way instead if you prefer SHA-256.

I used AI assistance while working on this. I confirmed the two now agree over the same string rather than assuming it.